### PR TITLE
regenerate package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,13 @@
     "less",
     "css",
     "flexbox"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codio/Flex.less.git"
+  },
+  "bugs": {
+    "url": "https://github.com/codio/Flex.less/issues"
+  },
+  "homepage": "https://github.com/codio/Flex.less"
 }


### PR DESCRIPTION
Since we are using Webpack, packages a installed with npm.
And npm gives warnings:

```
➤➤ npm i
npm WARN package.json flex.less@1.1.0 No repository field.
```

I ran `npm init` again to generate the repo fields:
